### PR TITLE
Add UVC camera control relay for Raspberry Pi Zero 2W

### DIFF
--- a/board/raspberrypizero2w-64/post-image.sh
+++ b/board/raspberrypizero2w-64/post-image.sh
@@ -20,7 +20,7 @@ if [ ! -e "${GENIMAGE_CFG}" ]; then
 	FILES+=( "${KERNEL}" )
 
 	BOOT_FILES=$(printf '\\t\\t\\t"%s",\\n' "${FILES[@]}")
-	sed "s|#BOOT_FILES#|${BOOT_FILES}|" "${BR2_EXTERNAL_WEBCAMPI_PATH}/board/raspberrypizero2w-64/genimage.cfg.in" \
+	sed "s|#BOOT_FILES#|${BOOT_FILES}|" "${BOARD_DIR}/genimage.cfg.in" \
 		> "${GENIMAGE_CFG}"
 fi
 

--- a/package/uvc-gadget/uvc-gadget.mk
+++ b/package/uvc-gadget/uvc-gadget.mk
@@ -4,7 +4,7 @@
 #
 ################################################################################
 
-UVC_GADGET_VERSION = v0.4.4
+UVC_GADGET_VERSION = v0.5.0
 UVC_GADGET_SITE = https://github.com/elcalzado/uvc-gadget.git
 UVC_GADGET_SITE_METHOD = git
 UVC_GADGET_LICENSE = NONE


### PR DESCRIPTION
This is the result of pointing copilot to issue #3 and shepherding it back and froth towards a minimal working solution. I take no credit nor responsibility for the code.
However, this turns the webcampi image into a working replacement for  pi-webcam, which I used on the original RPI Zero W.

Thanks for your original work on this image!

## Summary

This PR adds support for relaying UVC camera controls from the host PC through to libcamera on the Pi, enabling host applications (e.g. OBS, v4l2-ctl) to adjust the camera image in real time.

Also includes a bug fix for the post-image.sh build script. (this is unrelated but harmless).




## Changes

### Bug fix
- **`board/raspberrypizero2w-64/post-image.sh`**: Use the standard `$BOARD_DIR` variable instead of constructing the path manually from `$BR2_EXTERNAL_WEBCAMPI_PATH`. The old code produced an incorrect path and broke `make all` with `sed: can't read /board/raspberrypizero2w-64/genimage.cfg.in`.

### uvc-gadget patches

**`0003-script-configure-uvc-controls.patch`**
Writes `bmControls` bytes to configfs at gadget init so the host kernel exposes the right set of controls:
- Processing Unit: brightness, contrast, saturation, sharpness, white-balance temperature, WB temperature auto, power-line frequency
- Camera Terminal: AE mode, exposure time absolute
- Hue and gamma intentionally omitted — the RPi IPA has no handler for either

**`0004-uvc-add-control-relay.patch`**
Implements the actual relay from UVC SET_CUR to libcamera:
- Brightness / contrast / saturation / sharpness forwarded as libcamera floats
- White-balance auto (`AwbEnable`) and temperature (`ColourTemperature`)
- Power-line frequency mapped to `AeFlickerMode` / `AeFlickerPeriod` (0=off, 1=50 Hz→10 ms, 2=60 Hz→8.3 ms)
- AE mode uses `ExposureTimeMode` + `AnalogueGainMode` (the RPi IPA silently ignores `AeEnable`)
- Exposure time absolute forwarded as `ExposureTime` in µs when AE is in manual mode
- CT AE Mode CS (0x02) conflicts with PU Brightness CS (0x02); disambiguation by entity_id with a synthetic virtual CS for forwarding
- All controls initialised to user-tuned defaults so the image is correct from the first frame

## Tested on
- Raspberry Pi Zero 2W (aarch64, Buildroot)
- Camera: [Raspberry Pi High Quality Camera (12.3 megapixel Sony IMX477)](https://www.raspberrypi.com/products/raspberry-pi-high-quality-camera/)
- Host: Debian Linux, v4l2-ctl, guvcview